### PR TITLE
Update composer dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
 		"silverstripe/framework": "~3.1",
 		"colymba/gridfield-bulk-editing-tools": "~2.1",
 		"unclecheese/betterbuttons": "~1.2",
-		"silverstripe-australia/gridfieldextensions": "~1.2",
+		"symbiote/silverstripe-gridfieldextensions": "~1.2",
 		"bummzack/sortablefile": "~1.2"
 	},
 	"extra": {


### PR DESCRIPTION
Package silverstripe-australia/gridfieldextensions is abandoned, you should avoid using it. Use symbiote/silverstripe-gridfieldextensions instead.