### PR TITLE
FIX: CMS fields issue

### DIFF
--- a/code/extensions/PageBlocks.php
+++ b/code/extensions/PageBlocks.php
@@ -26,9 +26,8 @@ class PageBlocks extends DataExtension
             $this->owner->Blocks(), $gridConfig);
         $gridField->setModelClass('Block');
 
-        $fields->addFieldsToTab('Root.Main', array(
-            $gridField
-        ), 'Metadata');
+        $tab = $fields->findOrMakeTab('Root.BlocksTab', _t('PageBlocks.BlocksTab', 'Blocks'));
+        $tab->push($gridField);
     }
 
     /**


### PR DESCRIPTION
This function won't work in case CMS was modified or in case extension extends an object:
$fields->addFieldsToTab('Root.Main', array(
            $gridField
        ), 'Metadata');